### PR TITLE
Add parallelize to benchmark script

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -2,6 +2,7 @@ var max = 1000000
 var parallel = require('./')()
 var parallelNoResults = require('./')({ results: false })
 var async = require('async')
+var parallelize = require('parallelize')
 var obj = {}
 
 function bench (func, done) {
@@ -41,6 +42,14 @@ function benchFastParallelEachResults (done) {
 
 function benchAsyncParallel (done) {
   async.parallel([somethingA, somethingA, somethingA], done)
+}
+
+function benchParallelize (done) {
+  var next = parallelize(done)
+
+  somethingA(next())
+  somethingA(next())
+  somethingA(next())
 }
 
 function benchAsyncEach (done) {
@@ -83,6 +92,7 @@ function runBench (done) {
     benchAsyncParallel,
     benchAsyncEach,
     benchAsyncMap,
+    benchParallelize,
     benchFastParallel,
     benchFastParallelNoResults,
     benchFastParallelEachResults,

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "async": "^0.9.0",
     "faucet": "0.0.1",
+    "parallelize": "^2.2.0",
     "pre-commit": "^1.0.6",
     "standard": "^3.0.0",
     "tape": "^3.5.0"


### PR DESCRIPTION
Hey there, while [parallelize](https://github.com/alessioalex/parallelize) doesn't have the same syntax as `fastparallel` or `async.parallel` I was still curious to see how it compares to the rest. I'm not sure if you'd be interested in adding it, but I figured I already wrote the code locally so no harm in a pull request.