### PR TITLE
Support ordered results

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ and map!
 
 Benchmark for doing 3 calls `setImmediate` 1 million times:
 
-* non-reusable `setImmediate`: 2172ms
-* `async.parallel`: 5739ms
-* `async.each`: 3015ms
-* `async.map`: 4981ms
-* `parallelize`: 3125ms
-* `fastparallel` with results: 2391ms
-* `fastparallel` without results: 2350ms
-* `fastparallel` map: 2351ms
-* `fastparallel` each: 2359ms
+* non-reusable `setImmediate`: 2453ms
+* `async.parallel`: 4269ms
+* `async.each`: 3286ms
+* `async.map`: 3822ms
+* `parallelize`: 3057ms
+* `fastparallel` with results: 2883ms
+* `fastparallel` without results: 2620ms
+* `fastparallel` map: 2839ms
+* `fastparallel` each: 2604ms
 
-These benchmarks where taken via `bench.js` on iojs 2.2.1, on a MacBook
+These benchmarks where taken via `bench.js` on node v4.0.0, on a MacBook
 Pro Retina 2014.
 
 If you need zero-overhead series function call, check out
@@ -24,6 +24,9 @@ check out [fastq](http://npm.im/fastq). If you need to run fast
 waterfall calls, use [fastfall](http://npm.im/fastfall).
 
 [![js-standard-style](https://raw.githubusercontent.com/feross/standard/master/badge.png)](https://github.com/feross/standard)
+
+__The major difference between version 1.x.x and 2.x.x is the order of
+results__, this is now ready to replace async in every case.
 
 ## Example for parallel call
 
@@ -93,8 +96,7 @@ function completed () {
 
 ## Caveats
 
-The `results` array will be non-ordered, and the `done` function will
-be called only once, even if more than one error happen.
+The `done` function will be called only once, even if more than one error happen.
 
 This library works by caching the latest used function, so that running a new parallel
 does not cause **any memory allocations**.

--- a/parallel.js
+++ b/parallel.js
@@ -12,11 +12,13 @@ function fastparallel (options) {
 
   var released = options.released
   var queue = reusify(options.results ? ResultsHolder : NoResultsHolder)
+  var queueSingleCaller = reusify(SingleCaller)
+  var goArray = options.results ? goResultsArray : goNoResultsArray
+  var goFunc = options.results ? goResultsFunc : goNoResultsFunc
 
   return parallel
 
   function parallel (that, toCall, arg, done) {
-    var i
     var holder = queue.get()
     done = done || nop
     if (toCall.length === 0) {
@@ -26,16 +28,11 @@ function fastparallel (options) {
       holder._callback = done
       holder._callThat = that
       holder._release = release
+
       if (typeof toCall === 'function') {
-        holder._count = arg.length
-        for (i = 0; i < arg.length; i++) {
-          toCall.call(that, arg[i], holder.release)
-        }
+        goFunc(that, toCall, arg, holder)
       } else {
-        holder._count = toCall.length
-        for (i = 0; i < toCall.length; i++) {
-          toCall[i].call(that, arg, holder.release)
-        }
+        goArray(that, toCall, arg, holder)
       }
 
       if (holder._count === 0) {
@@ -47,6 +44,50 @@ function fastparallel (options) {
   function release (holder) {
     queue.release(holder)
     released(holder)
+  }
+
+  function singleCallerRelease (holder) {
+    queueSingleCaller.release(holder)
+  }
+
+  function goResultsFunc (that, toCall, arg, holder) {
+    var singleCaller = null
+    holder._count = arg.length
+    holder._results = new Array(holder._count)
+    for (var i = 0; i < arg.length; i++) {
+      singleCaller = queueSingleCaller.get()
+      singleCaller._release = singleCallerRelease
+      singleCaller.parent = holder
+      singleCaller.pos = i
+      toCall.call(that, arg[i], singleCaller.release)
+    }
+  }
+
+  function goResultsArray (that, toCall, arg, holder) {
+    var singleCaller = null
+    holder._count = toCall.length
+    holder._results = new Array(holder._count)
+    for (var i = 0; i < toCall.length; i++) {
+      singleCaller = queueSingleCaller.get()
+      singleCaller._release = singleCallerRelease
+      singleCaller.parent = holder
+      singleCaller.pos = i
+      toCall[i].call(that, arg, singleCaller.release)
+    }
+  }
+
+  function goNoResultsFunc (that, toCall, arg, holder) {
+    holder._count = arg.length
+    for (var i = 0; i < arg.length; i++) {
+      toCall.call(that, arg[i], holder.release)
+    }
+  }
+
+  function goNoResultsArray (that, toCall, arg, holder) {
+    holder._count = toCall.length
+    for (var i = 0; i < toCall.length; i++) {
+      toCall[i].call(that, arg, holder.release)
+    }
   }
 }
 
@@ -70,24 +111,40 @@ function NoResultsHolder () {
   }
 }
 
-function ResultsHolder (_release) {
+function SingleCaller () {
+  this.pos = -1
+  this._release = nop
+  this.parent = null
+  this.next = null
+
+  var that = this
+  this.release = function (err, result) {
+    that.parent.release(err, that.pos, result)
+    that.pos = -1
+    that.parent = null
+    that._release(that)
+  }
+}
+
+function ResultsHolder () {
   this._count = -1
   this._callback = nop
-  this._results = []
+  this._results = null
   this._err = null
   this._callThat = null
-  this._release = null
+  this._release = nop
   this.next = null
 
   var that = this
   var i = 0
-  this.release = function (err, result) {
+  this.release = function (err, pos, result) {
     that._err = that._err || err
-    that._results[i] = result
+    that._results[pos] = result
+
     if (++i === that._count || that._count === 0) {
       that._callback.call(that._callThat, that._err, that._results)
       that._callback = nop
-      that._results = []
+      that._results = null
       that._err = null
       that._callThat = null
       i = 0

--- a/test.js
+++ b/test.js
@@ -318,3 +318,32 @@ test('works with sync functions with no results', function (t) {
     t.pass('release')
   }
 })
+
+test('accumulates results in order', function (t) {
+  t.plan(8)
+
+  var instance = parallel({
+    released: released
+  })
+  var count = 2
+  var obj = {}
+
+  instance(obj, [something, something], 42, function done (err, results) {
+    t.notOk(err, 'no error')
+    t.equal(count, 0, 'all functions must have completed')
+    t.deepEqual(results, [2, 1])
+  })
+
+  function something (arg, cb) {
+    t.equal(obj, this)
+    t.equal(arg, 42)
+    var value = count--
+    setTimeout(function () {
+      cb(null, value)
+    }, 10 * value)
+  }
+
+  function released () {
+    t.pass()
+  }
+})


### PR DESCRIPTION
I would bump this to 2.x.x, given the major change of behavior.

After this change this lib is completely 1-1 to `async.parallel`, `async.each` and `async.map`.

@deadfolk @mcdonnelldean can you please have a look if this sounds fine?